### PR TITLE
ContextAttribs and PixelFormat builder without unexpected behaviour

### DIFF
--- a/src/java/org/lwjgl/opengl/ContextAttribs.java
+++ b/src/java/org/lwjgl/opengl/ContextAttribs.java
@@ -65,45 +65,46 @@ public final class ContextAttribs {
 
 	private static final int CONTEXT_ROBUST_ACCESS_BIT_ARB           = 0x00000004;
 	private static final int CONTEXT_RESET_NOTIFICATION_STRATEGY_ARB = 0x8256;
-	private static final int
-	                         NO_RESET_NOTIFICATION_ARB               = 0x8261,
-		LOSE_CONTEXT_ON_RESET_ARB                                    = 0x8252;
+	private static final int NO_RESET_NOTIFICATION_ARB               = 0x8261;
+	private static final int LOSE_CONTEXT_ON_RESET_ARB               = 0x8252;
 
 	private static final int CONTEXT_RESET_ISOLATION_BIT_ARB = 0x00000008;
 
-	private int majorVersion;
-	private int minorVersion;
+	private final int majorVersion;
+	private final int minorVersion;
 
-	private int layerPlane;
+	private final int layerPlane;
 
-	private boolean debug;
-	private boolean forwardCompatible;
-	private boolean robustAccess;
+	private final boolean debug;
+	private final boolean forwardCompatible;
+	private final boolean robustAccess;
 
-	private boolean profileCore;
-	private boolean profileCompatibility;
-	private boolean profileES;
+	private final boolean profileCore;
+	private final boolean profileCompatibility;
+	private final boolean profileES;
 
-	private boolean loseContextOnReset;
-	private boolean contextResetIsolation;
+	private final boolean loseContextOnReset;
+	private final boolean contextResetIsolation;
 
-	public ContextAttribs() {
-		this(1, 0);
+	
+	private ContextAttribs(Builder builder) {
+		this.majorVersion = builder.majorVersion;
+		this.minorVersion = builder.minorVersion;
+
+		this.layerPlane = builder.layerPlane;
+
+		this.debug = builder.debug;
+		this.forwardCompatible = builder.forwardCompatible;
+		this.robustAccess = builder.robustAccess;
+
+		this.profileCore = builder.profileCore;
+		this.profileCompatibility = builder.profileCompatibility;
+		this.profileES = builder.profileES;
+
+		this.loseContextOnReset = builder.loseContextOnReset;
+		this.contextResetIsolation = builder.contextResetIsolation;
 	}
-
-	public ContextAttribs(final int majorVersion, final int minorVersion) {
-		if ( majorVersion < 0 || 4 < majorVersion ||
-		     minorVersion < 0 ||
-		     (majorVersion == 4 && 3 < minorVersion) ||
-		     (majorVersion == 3 && 3 < minorVersion) ||
-		     (majorVersion == 2 && 1 < minorVersion) ||
-		     (majorVersion == 1 && 5 < minorVersion) )
-			throw new IllegalArgumentException("Invalid OpenGL version specified: " + majorVersion + '.' + minorVersion);
-
-		this.majorVersion = majorVersion;
-		this.minorVersion = minorVersion;
-	}
-
+	
 	private ContextAttribs(final ContextAttribs attribs) {
 		this.majorVersion = attribs.majorVersion;
 		this.minorVersion = attribs.minorVersion;
@@ -119,7 +120,117 @@ public final class ContextAttribs {
 		this.profileES = attribs.profileES;
 
 		this.loseContextOnReset = attribs.loseContextOnReset;
+		this.contextResetIsolation = attribs.contextResetIsolation;
 	}
+	
+	public static class Builder {
+		private int majorVersion;
+		private int minorVersion;
+
+		private int layerPlane;
+
+		private boolean debug;
+		private boolean forwardCompatible;
+		private boolean robustAccess;
+
+		private boolean profileCore;
+		private boolean profileCompatibility;
+		private boolean profileES;
+
+		private boolean loseContextOnReset;
+		private boolean contextResetIsolation;
+
+		
+		public Builder() {
+			this(1, 0);
+		}
+
+		public Builder(final int majorVersion, final int minorVersion) {
+			if ( majorVersion < 0 || 4 < majorVersion ||
+			     minorVersion < 0 ||
+			     (majorVersion == 4 && 3 < minorVersion) ||
+			     (majorVersion == 3 && 3 < minorVersion) ||
+			     (majorVersion == 2 && 1 < minorVersion) ||
+			     (majorVersion == 1 && 5 < minorVersion) )
+				throw new IllegalArgumentException("Invalid OpenGL version specified: " + majorVersion + '.' + minorVersion);
+
+			this.majorVersion = majorVersion;
+			this.minorVersion = minorVersion;
+		}
+
+		public Builder withLayer(final int layerPlane) {
+			if ( layerPlane < 0 )
+				throw new IllegalArgumentException("Invalid layer plane specified: " + layerPlane);
+
+			this.layerPlane = layerPlane;
+			return this;
+		}
+
+		public Builder withDebug(final boolean debug) {
+			this.debug = debug;
+			return this;
+		}
+
+		public Builder withForwardCompatible(final boolean forwardCompatible) {
+			this.forwardCompatible = forwardCompatible;
+			return this;
+		}
+
+		public Builder withProfileCore(final boolean profileCore) {
+			if ( majorVersion < 3 || (majorVersion == 3 && minorVersion < 2) )
+				throw new IllegalArgumentException("Profiles are only supported on OpenGL version 3.2 or higher.");
+
+			this.profileCore = profileCore;
+			if ( profileCore )
+				this.profileCompatibility = false;
+
+			return this;
+		}
+
+		public Builder withProfileCompatibility(final boolean profileCompatibility) {
+			if ( majorVersion < 3 || (majorVersion == 3 && minorVersion < 2) )
+				throw new IllegalArgumentException("Profiles are only supported on OpenGL version 3.2 or higher.");
+
+			this.profileCompatibility = profileCompatibility;
+			if ( profileCompatibility )
+				this.profileCore = false;
+
+			return this;
+		}
+
+		public Builder withProfileES(final boolean profileES) {
+			if ( !(majorVersion == 2 && minorVersion == 0) )
+				throw new IllegalArgumentException("The OpenGL ES profiles is only supported for OpenGL version 2.0.");
+
+			this.profileES = profileES;
+
+			return this;
+		}
+
+		/**
+		 * Returns a ContextAttribs instance with CONTEXT_RESET_NOTIFICATION_STRATEGY set
+		 * to LOSE_CONTEXT_ON_RESET if the parameter is true or to NO_RESET_NOTIFICATION
+		 * if the parameter is false.
+		 *
+		 * @param loseContextOnReset
+		 *
+		 * @return the new ContextAttribs
+		 */
+		public Builder withLoseContextOnReset(final boolean loseContextOnReset) {
+			this.loseContextOnReset = loseContextOnReset;
+			return this;
+		}
+
+		public Builder withContextResetIsolation(final boolean contextResetIsolation) {
+			this.contextResetIsolation = contextResetIsolation;
+			return this;
+		}
+		
+		public ContextAttribs build() {
+			return new ContextAttribs(this);
+		}
+	}
+	
 
 	public int getMajorVersion() {
 		return majorVersion;
@@ -151,74 +262,6 @@ public final class ContextAttribs {
 
 	public boolean isProfileES() {
 		return profileES;
-	}
-
-	public ContextAttribs withLayer(final int layerPlane) {
-		if ( layerPlane < 0 )
-			throw new IllegalArgumentException("Invalid layer plane specified: " + layerPlane);
-
-		this.layerPlane = layerPlane;
-		return this;
-	}
-
-	public ContextAttribs withDebug(final boolean debug) {
-		this.debug = debug;
-		return this;
-	}
-
-	public ContextAttribs withForwardCompatible(final boolean forwardCompatible) {
-		this.forwardCompatible = forwardCompatible;
-		return this;
-	}
-
-	public ContextAttribs withProfileCore(final boolean profileCore) {
-		if ( majorVersion < 3 || (majorVersion == 3 && minorVersion < 2) )
-			throw new IllegalArgumentException("Profiles are only supported on OpenGL version 3.2 or higher.");
-
-		this.profileCore = profileCore;
-		if ( profileCore )
-			this.profileCompatibility = false;
-
-		return this;
-	}
-
-	public ContextAttribs withProfileCompatibility(final boolean profileCompatibility) {
-		if ( majorVersion < 3 || (majorVersion == 3 && minorVersion < 2) )
-			throw new IllegalArgumentException("Profiles are only supported on OpenGL version 3.2 or higher.");
-
-		this.profileCompatibility = profileCompatibility;
-		if ( profileCompatibility )
-			this.profileCore = false;
-
-		return this;
-	}
-
-	public ContextAttribs withProfileES(final boolean profileES) {
-		if ( !(majorVersion == 2 && minorVersion == 0) )
-			throw new IllegalArgumentException("The OpenGL ES profiles is only supported for OpenGL version 2.0.");
-
-		this.profileES = profileES;
-
-		return this;
-	}
-
-	/**
-	 * Returns a ContextAttribs instance with CONTEXT_RESET_NOTIFICATION_STRATEGY set
-	 * to LOSE_CONTEXT_ON_RESET if the parameter is true or to NO_RESET_NOTIFICATION
-	 * if the parameter is false.
-	 *
-	 * @param loseContextOnReset
-	 *
-	 * @return the new ContextAttribs
-	 */
-	public ContextAttribs withLoseContextOnReset(final boolean loseContextOnReset) {
-		this.loseContextOnReset = loseContextOnReset;
-		return this;
-	}
-
-	public ContextAttribs withContextResetIsolation(final boolean contextResetIsolation) {
-		this.contextResetIsolation = contextResetIsolation;
-		return this;
 	}
 
 	private static ContextAttribsImplementation getImplementation() {

--- a/src/java/org/lwjgl/opengl/PixelFormat.java
+++ b/src/java/org/lwjgl/opengl/PixelFormat.java
@@ -52,18 +52,18 @@ public final class PixelFormat implements PixelFormatLWJGL {
 	 * The number of bits per pixel, exluding alpha.
 	 * This parameter is ignored in Display.create().
 	 */
-	private int bpp;
+	private final int bpp;
 	/** The number of alpha bits. */
-	private int alpha;
+	private final int alpha;
 	/** The number of depth buffer bits */
-	private int depth;
+	private final int depth;
 	/** The number of stencil bits */
-	private int stencil;
+	private final int stencil;
 	/**
 	 * The number of samples to use in anti-aliasing.
 	 * 0 means that anti-aliasing is disabled.
 	 */
-	private int samples;
+	private final int samples;
 	/**
 	 * The number of COLOR_SAMPLES_NV to use for Coverage Sample Anti-aliasing (CSAA).
 	 * When this number is greater than 0, the {@code samples} property will be treated
@@ -71,71 +71,50 @@ public final class PixelFormat implements PixelFormatLWJGL {
 	 * <p/>
 	 * This property is currently a no-op for the MacOS implementation.
 	 */
-	private int colorSamples;
+	private final int colorSamples;
 	/** The number of auxiliary buffers */
-	private int num_aux_buffers;
+	private final int num_aux_buffers;
 	/** The number of bits per pixel in the accumulation buffer */
-	private int accum_bpp;
+	private final int accum_bpp;
 	/** The number of alpha bits in the accumulation buffer */
-	private int accum_alpha;
+	private final int accum_alpha;
 	/** Whether this format requires a stereo buffer */
-	private boolean stereo;
+	private final boolean stereo;
 	/** Whether this format specifies a floating point format */
-	private boolean floating_point;
+	private final boolean floating_point;
 	/**
 	 * Whether this format specifies a packed floating point format (32 bit unsigned - R11F_G11F_B10F)
 	 * This property is currently a no-op for the MacOS implementation.
 	 */
-	private boolean floating_point_packed;
+	private final boolean floating_point_packed;
 	/**
 	 * Whether this format specifies an sRGB format
 	 * This property is currently a no-op for the MacOS implementation.
 	 */
-	private boolean sRGB;
+	private final boolean sRGB;
 
-	/**
-	 * Default pixel format is minimum 8 bits depth, and no alpha
-	 * nor stencil requirements.
-	 */
-	public PixelFormat() {
-		this(0, 8, 0);
+
+	private PixelFormat(final Builder builder) {
+		this.bpp = builder.bpp;
+		this.alpha = builder.alpha;
+		this.depth = builder.depth;
+		this.stencil = builder.stencil;
+
+		this.samples = builder.samples;
+		this.colorSamples = builder.colorSamples;
+
+		this.num_aux_buffers = builder.num_aux_buffers;
+
+		this.accum_bpp = builder.accum_bpp;
+		this.accum_alpha = builder.accum_alpha;
+
+		this.stereo = builder.stereo;
+
+		this.floating_point = builder.floating_point;
+		this.floating_point_packed = builder.floating_point_packed;
+		this.sRGB = builder.sRGB;
 	}
 
-	public PixelFormat(int alpha, int depth, int stencil) {
-		this(alpha, depth, stencil, 0);
-	}
-
-	public PixelFormat(int alpha, int depth, int stencil, int samples) {
-		this(0, alpha, depth, stencil, samples);
-	}
-
-	public PixelFormat(int bpp, int alpha, int depth, int stencil, int samples) {
-		this(bpp, alpha, depth, stencil, samples, 0, 0, 0, false);
-	}
-
-	public PixelFormat(int bpp, int alpha, int depth, int stencil, int samples, int num_aux_buffers, int accum_bpp, int accum_alpha, boolean stereo) {
-		this(bpp, alpha, depth, stencil, samples, num_aux_buffers, accum_bpp, accum_alpha, stereo, false);
-	}
-
-	public PixelFormat(int bpp, int alpha, int depth, int stencil, int samples, int num_aux_buffers, int accum_bpp, int accum_alpha, boolean stereo, boolean floating_point) {
-		this.bpp = bpp;
-		this.alpha = alpha;
-		this.depth = depth;
-		this.stencil = stencil;
-
-		this.samples = samples;
-
-		this.num_aux_buffers = num_aux_buffers;
-
-		this.accum_bpp = accum_bpp;
-		this.accum_alpha = accum_alpha;
-
-		this.stereo = stereo;
-
-		this.floating_point = floating_point;
-		this.floating_point_packed = false;
-		this.sRGB = false;
-	}
 
 	private PixelFormat(final PixelFormat pf) {
 		this.bpp = pf.bpp;
@@ -157,253 +136,350 @@ public final class PixelFormat implements PixelFormatLWJGL {
 		this.floating_point_packed = pf.floating_point_packed;
 		this.sRGB = pf.sRGB;
 	}
+	
+	
+	public static class Builder {
+		/**
+		 * The number of bits per pixel, exluding alpha.
+		 * This parameter is ignored in Display.create().
+		 */
+		private int bpp;
+		/** The number of alpha bits. */
+		private int alpha;
+		/** The number of depth buffer bits */
+		private int depth;
+		/** The number of stencil bits */
+		private int stencil;
+		/**
+		 * The number of samples to use in anti-aliasing.
+		 * 0 means that anti-aliasing is disabled.
+		 */
+		private int samples;
+		/**
+		 * The number of COLOR_SAMPLES_NV to use for Coverage Sample Anti-aliasing (CSAA).
+		 * When this number is greater than 0, the {@code samples} property will be treated
+		 * as if it were the COVERAGE_SAMPLES_NV property.
+		 * <p/>
+		 * This property is currently a no-op for the MacOS implementation.
+		 */
+		private int colorSamples;
+		/** The number of auxiliary buffers */
+		private int num_aux_buffers;
+		/** The number of bits per pixel in the accumulation buffer */
+		private int accum_bpp;
+		/** The number of alpha bits in the accumulation buffer */
+		private int accum_alpha;
+		/** Whether this format requires a stereo buffer */
+		private boolean stereo;
+		/** Whether this format specifies a floating point format */
+		private boolean floating_point;
+		/**
+		 * Whether this format specifies a packed floating point format (32 bit unsigned - R11F_G11F_B10F)
+		 * This property is currently a no-op for the MacOS implementation.
+		 */
+		private boolean floating_point_packed;
+		/**
+		 * Whether this format specifies an sRGB format
+		 * This property is currently a no-op for the MacOS implementation.
+		 */
+		private boolean sRGB;
+	
+		
+		/**
+		 * Default pixel format is minimum 8 bits depth, and no alpha
+		 * nor stencil requirements.
+		 */
+		public Builder() {
+			this(0, 8, 0);
+		}
+
+		public Builder(int alpha, int depth, int stencil) {
+			this(alpha, depth, stencil, 0);
+		}
+
+		public Builder(int alpha, int depth, int stencil, int samples) {
+			this(0, alpha, depth, stencil, samples);
+		}
+
+		public Builder(int bpp, int alpha, int depth, int stencil, int samples) {
+			this(bpp, alpha, depth, stencil, samples, 0, 0, 0, false);
+		}
+
+		public Builder(int bpp, int alpha, int depth, int stencil, int samples, int num_aux_buffers, int accum_bpp, int accum_alpha, boolean stereo) {
+			this(bpp, alpha, depth, stencil, samples, num_aux_buffers, accum_bpp, accum_alpha, stereo, false);
+		}
+
+		public Builder(int bpp, int alpha, int depth, int stencil, int samples, int num_aux_buffers, int accum_bpp, int accum_alpha, boolean stereo, boolean floating_point) {
+			this.bpp = bpp;
+			this.alpha = alpha;
+			this.depth = depth;
+			this.stencil = stencil;
+
+			this.samples = samples;
+
+			this.num_aux_buffers = num_aux_buffers;
+
+			this.accum_bpp = accum_bpp;
+			this.accum_alpha = accum_alpha;
+
+			this.stereo = stereo;
+
+			this.floating_point = floating_point;
+			this.floating_point_packed = false;
+			this.sRGB = false;
+		}
+
+		/**
+		 * Returns this, updated with the new bits per pixel value.
+		 *
+		 * @param bpp the new bits per pixel value.
+		 *
+		 * @return this
+		 */
+		public Builder withBitsPerPixel(final int bpp) {
+			if ( bpp < 0 )
+				throw new IllegalArgumentException("Invalid number of bits per pixel specified: " + bpp);
+
+			this.bpp = bpp;
+			return this;
+		}
+
+		/**
+		 * Returns this, updated with the new alpha bits value.
+		 *
+		 * @param alpha the new alpha bits value.
+		 *
+		 * @return this
+		 */
+		public Builder withAlphaBits(final int alpha) {
+			if ( alpha < 0 )
+				throw new IllegalArgumentException("Invalid number of alpha bits specified: " + alpha);
+
+			this.alpha = alpha;
+			return this;
+		}
+
+		/**
+		 * Returns this, updated with the new depth bits value.
+		 *
+		 * @param depth the new depth bits value.
+		 *
+		 * @return this
+		 */
+		public Builder withDepthBits(final int depth) {
+			if ( depth < 0 )
+				throw new IllegalArgumentException("Invalid number of depth bits specified: " + depth);
+
+			this.depth = depth;
+			return this;
+		}
+
+		/**
+		 * Returns this, updated with the new stencil bits value.
+		 *
+		 * @param stencil the new stencil bits value.
+		 *
+		 * @return this
+		 */
+		public Builder withStencilBits(final int stencil) {
+			if ( stencil < 0 )
+				throw new IllegalArgumentException("Invalid number of stencil bits specified: " + stencil);
+
+			this.stencil = stencil;
+			return this;
+		}
+
+		/**
+		 * Returns this, updated with the new samples value.
+		 *
+		 * @param samples the new samples value.
+		 *
+		 * @return this
+		 */
+		public Builder withSamples(final int samples) {
+			if ( samples < 0 )
+				throw new IllegalArgumentException("Invalid number of samples specified: " + samples);
+
+			this.samples = samples;
+			return this;
+		}
+
+		/**
+		 * Returns this, updated with the new color samples values.
+		 * A value greater than 0 is valid only if the {@code samples} property is also greater than 0. Additionally, the
+		 * color samples value needs to be lower than or equal to the {@code samples} property.
+		 *
+		 * @param colorSamples the new color samples value.
+		 *
+		 * @return this
+		 */
+		public Builder withCoverageSamples(final int colorSamples) {
+			return withCoverageSamples(colorSamples, samples);
+		}
+
+		/**
+		 * Returns this, updated with the new color samples and coverage samples values.
+		 *
+		 * @param colorSamples    the new color samples value. This value must be lower than or equal to the coverage samples value.
+		 * @param coverageSamples the new coverage samples value.
+		 *
+		 * @return this
+		 */
+		public Builder withCoverageSamples(final int colorSamples, final int coverageSamples) {
+			if ( coverageSamples < 0 || colorSamples < 0 || (coverageSamples == 0 && 0 < colorSamples) || coverageSamples < colorSamples  )
+				throw new IllegalArgumentException("Invalid number of coverage samples specified: " + coverageSamples + " - " + colorSamples);
+
+			this.samples = coverageSamples;
+			this.colorSamples = colorSamples;
+			return this;
+		}
+
+		/**
+		 * Returns this, updated with the new auxiliary buffers value.
+		 *
+		 * @param num_aux_buffers the new auxiliary buffers value.
+		 *
+		 * @return this
+		 */
+		public Builder withAuxBuffers(final int num_aux_buffers) {
+			if ( num_aux_buffers < 0 )
+				throw new IllegalArgumentException("Invalid number of auxiliary buffers specified: " + num_aux_buffers);
+
+			this.num_aux_buffers = num_aux_buffers;
+			return this;
+		}
+
+		/**
+		 * Returns this, updated with the new bits per pixel in the accumulation buffer value.
+		 *
+		 * @param accum_bpp the new bits per pixel in the accumulation buffer value.
+		 *
+		 * @return this
+		 */
+		public Builder withAccumulationBitsPerPixel(final int accum_bpp) {
+			if ( accum_bpp < 0 )
+				throw new IllegalArgumentException("Invalid number of bits per pixel in the accumulation buffer specified: " + accum_bpp);
+
+			this.accum_bpp = accum_bpp;
+			return this;
+		}
+
+		/**
+		 * Returns this, updated with the new alpha bits in the accumulation buffer value.
+		 *
+		 * @param accum_alpha the new alpha bits in the accumulation buffer value.
+		 *
+		 * @return this
+		 */
+		public Builder withAccumulationAlpha(final int accum_alpha) {
+			if ( accum_alpha < 0 )
+				throw new IllegalArgumentException("Invalid number of alpha bits in the accumulation buffer specified: " + accum_alpha);
+
+			this.accum_alpha = accum_alpha;
+			return this;
+		}
+
+		/**
+		 * Returns this, updated with the new stereo value.
+		 *
+		 * @param stereo the new stereo value.
+		 *
+		 * @return this
+		 */
+		public Builder withStereo(final boolean stereo) {
+			this.stereo = stereo;
+			return this;
+		}
+
+		/**
+		 * Returns this, updated with the new floating point value.
+		 * If floating_point is true, floating_point_packed will be reset to false.
+		 *
+		 * @param floating_point the new floating point value.
+		 *
+		 * @return this
+		 */
+		public Builder withFloatingPoint(final boolean floating_point) {
+			this.floating_point = floating_point;
+			if ( floating_point )
+				this.floating_point_packed = false;
+			return this;
+		}
+
+		/**
+		 * Returns this, updated with the new packed floating point value.
+		 * If floating_point_packed is true, floating_point will be reset to false.
+		 *
+		 * @param floating_point_packed the new packed floating point value.
+		 *
+		 * @return this
+		 */
+		public Builder withFloatingPointPacked(final boolean floating_point_packed) {
+			this.floating_point_packed = floating_point_packed;
+			if ( floating_point_packed )
+				this.floating_point = false;
+			return this;
+		}
+
+		/**
+		 * Returns this, updated with the new sRGB value.
+		 *
+		 * @param sRGB the new floating point value.
+		 *
+		 * @return this
+		 */
+		public Builder withSRGB(final boolean sRGB) {
+			this.sRGB = sRGB;
+			return this;
+		}
+		
+		public PixelFormat build() {
+			return new PixelFormat(this);
+		}
+	}
+	
 
 	public int getBitsPerPixel() {
 		return bpp;
-	}
-
-	/**
-	 * Returns this, updated with the new bits per pixel value.
-	 *
-	 * @param bpp the new bits per pixel value.
-	 *
-	 * @return this
-	 */
-	public PixelFormat withBitsPerPixel(final int bpp) {
-		if ( bpp < 0 )
-			throw new IllegalArgumentException("Invalid number of bits per pixel specified: " + bpp);
-
-		this.bpp = bpp;
-		return this;
 	}
 
 	public int getAlphaBits() {
 		return alpha;
 	}
 
-	/**
-	 * Returns this, updated with the new alpha bits value.
-	 *
-	 * @param alpha the new alpha bits value.
-	 *
-	 * @return this
-	 */
-	public PixelFormat withAlphaBits(final int alpha) {
-		if ( alpha < 0 )
-			throw new IllegalArgumentException("Invalid number of alpha bits specified: " + alpha);
-
-		this.alpha = alpha;
-		return this;
-	}
-
 	public int getDepthBits() {
 		return depth;
-	}
-
-	/**
-	 * Returns this, updated with the new depth bits value.
-	 *
-	 * @param depth the new depth bits value.
-	 *
-	 * @return this
-	 */
-	public PixelFormat withDepthBits(final int depth) {
-		if ( depth < 0 )
-			throw new IllegalArgumentException("Invalid number of depth bits specified: " + depth);
-
-		this.depth = depth;
-		return this;
 	}
 
 	public int getStencilBits() {
 		return stencil;
 	}
 
-	/**
-	 * Returns this, updated with the new stencil bits value.
-	 *
-	 * @param stencil the new stencil bits value.
-	 *
-	 * @return this
-	 */
-	public PixelFormat withStencilBits(final int stencil) {
-		if ( stencil < 0 )
-			throw new IllegalArgumentException("Invalid number of stencil bits specified: " + stencil);
-
-		this.stencil = stencil;
-		return this;
-	}
-
 	public int getSamples() {
 		return samples;
-	}
-
-	/**
-	 * Returns this, updated with the new samples value.
-	 *
-	 * @param samples the new samples value.
-	 *
-	 * @return this
-	 */
-	public PixelFormat withSamples(final int samples) {
-		if ( samples < 0 )
-			throw new IllegalArgumentException("Invalid number of samples specified: " + samples);
-
-		this.samples = samples;
-		return this;
-	}
-
-	/**
-	 * Returns this, updated with the new color samples values.
-	 * A value greater than 0 is valid only if the {@code samples} property is also greater than 0. Additionally, the
-	 * color samples value needs to be lower than or equal to the {@code samples} property.
-	 *
-	 * @param colorSamples the new color samples value.
-	 *
-	 * @return this
-	 */
-	public PixelFormat withCoverageSamples(final int colorSamples) {
-		return withCoverageSamples(colorSamples, samples);
-	}
-
-	/**
-	 * Returns this, updated with the new color samples and coverage samples values.
-	 *
-	 * @param colorSamples    the new color samples value. This value must be lower than or equal to the coverage samples value.
-	 * @param coverageSamples the new coverage samples value.
-	 *
-	 * @return this
-	 */
-	public PixelFormat withCoverageSamples(final int colorSamples, final int coverageSamples) {
-		if ( coverageSamples < 0 || colorSamples < 0 || (coverageSamples == 0 && 0 < colorSamples) || coverageSamples < colorSamples  )
-			throw new IllegalArgumentException("Invalid number of coverage samples specified: " + coverageSamples + " - " + colorSamples);
-
-		this.samples = coverageSamples;
-		this.colorSamples = colorSamples;
-		return this;
 	}
 
 	public int getAuxBuffers() {
 		return num_aux_buffers;
 	}
 
-	/**
-	 * Returns this, updated with the new auxiliary buffers value.
-	 *
-	 * @param num_aux_buffers the new auxiliary buffers value.
-	 *
-	 * @return this
-	 */
-	public PixelFormat withAuxBuffers(final int num_aux_buffers) {
-		if ( num_aux_buffers < 0 )
-			throw new IllegalArgumentException("Invalid number of auxiliary buffers specified: " + num_aux_buffers);
-
-		this.num_aux_buffers = num_aux_buffers;
-		return this;
-	}
-
 	public int getAccumulationBitsPerPixel() {
 		return accum_bpp;
-	}
-
-	/**
-	 * Returns this, updated with the new bits per pixel in the accumulation buffer value.
-	 *
-	 * @param accum_bpp the new bits per pixel in the accumulation buffer value.
-	 *
-	 * @return this
-	 */
-	public PixelFormat withAccumulationBitsPerPixel(final int accum_bpp) {
-		if ( accum_bpp < 0 )
-			throw new IllegalArgumentException("Invalid number of bits per pixel in the accumulation buffer specified: " + accum_bpp);
-
-		this.accum_bpp = accum_bpp;
-		return this;
 	}
 
 	public int getAccumulationAlpha() {
 		return accum_alpha;
 	}
 
-	/**
-	 * Returns this, updated with the new alpha bits in the accumulation buffer value.
-	 *
-	 * @param accum_alpha the new alpha bits in the accumulation buffer value.
-	 *
-	 * @return this
-	 */
-	public PixelFormat withAccumulationAlpha(final int accum_alpha) {
-		if ( accum_alpha < 0 )
-			throw new IllegalArgumentException("Invalid number of alpha bits in the accumulation buffer specified: " + accum_alpha);
-
-		this.accum_alpha = accum_alpha;
-		return this;
-	}
-
 	public boolean isStereo() {
 		return stereo;
-	}
-
-	/**
-	 * Returns this, updated with the new stereo value.
-	 *
-	 * @param stereo the new stereo value.
-	 *
-	 * @return this
-	 */
-	public PixelFormat withStereo(final boolean stereo) {
-		this.stereo = stereo;
-		return this;
 	}
 
 	public boolean isFloatingPoint() {
 		return floating_point;
 	}
 
-	/**
-	 * Returns this, updated with the new floating point value.
-	 * If floating_point is true, floating_point_packed will be reset to false.
-	 *
-	 * @param floating_point the new floating point value.
-	 *
-	 * @return this
-	 */
-	public PixelFormat withFloatingPoint(final boolean floating_point) {
-		this.floating_point = floating_point;
-		if ( floating_point )
-			this.floating_point_packed = false;
-		return this;
-	}
-
-	/**
-	 * Returns this, updated with the new packed floating point value.
-	 * If floating_point_packed is true, floating_point will be reset to false.
-	 *
-	 * @param floating_point_packed the new packed floating point value.
-	 *
-	 * @return this
-	 */
-	public PixelFormat withFloatingPointPacked(final boolean floating_point_packed) {
-		this.floating_point_packed = floating_point_packed;
-		if ( floating_point_packed )
-			this.floating_point = false;
-		return this;
-	}
-
 	public boolean isSRGB() {
 		return sRGB;
 	}
-
-	/**
-	 * Returns this, updated with the new sRGB value.
-	 *
-	 * @param sRGB the new floating point value.
-	 *
-	 * @return this
-	 */
-	public PixelFormat withSRGB(final boolean sRGB) {
-		this.sRGB = sRGB;
-		return this;
-	}
-
 }


### PR DESCRIPTION
Edited after original change was questioned.

I've committed versions of PixelFormat and ContextAttribs that are both fully immutable, and now use builders. The downside is that it's a breaking change.
