### PR TITLE
fix: correctly parse current config with xrandr 1.4

### DIFF
--- a/src/java/org/lwjgl/opengl/XRandR.java
+++ b/src/java/org/lwjgl/opengl/XRandR.java
@@ -86,7 +86,7 @@ public class XRandR
 						name = sa[ 0 ];
 
 						// record the current config
-						parseScreen( currentList, name, sa[ 2 ] );
+						parseScreen( currentList, name, "primary".equals(sa[ 2 ]) ? sa[ 3 ] : sa[ 2 ] );
 					}
 					else if( Pattern.matches( "\\d*x\\d*", sa[ 0 ] ) )
 					{


### PR DESCRIPTION
This fixes http://lwjgl.org/forum/index.php/topic,4920.0.html

Brief summary:
Xrandr 1.4 changed the output format to include information about which screen is the primary (relevant change in xrandr: http://cgit.freedesktop.org/xorg/app/xrandr/commit/?id=094b40e89707828df2bb7b204a97eed256a3c3fd)

This change breaks the parsing logic in XrandR.java. As a result, getConfiguration() returns an empty array.
When closing (windowed) lwjgl applications, the system assumes the display mode was changed and therefore resets it, causing the screen to turn black for a short moment.

According to xrandr.c "primary" is the only possible keyword here, so this change simply ignores it, if present.
