### PR TITLE
Replace carriage returns with line feeds

### DIFF
--- a/platform_build/macosx_ant/build.xml
+++ b/platform_build/macosx_ant/build.xml
@@ -1,1 +1,176 @@
-<project name="OS X Native code" basedir="../../bin/lwjgl" default="nativelibrary">	<property name="native" location="../../src/native"/>	<target name="init">		<mkdir dir="i386"/>		<mkdir dir="x86_64"/>		<property environment="env" />		<!-- Check which gcc we have, newer releasse of Mac OS do not have gcc-4.2 installed by defaault -->		<available file="gcc" filepath="${env.PATH}" property="gcc.name" value="gcc"/>		<available file="gcc-4.2" filepath="${env.PATH}" property="gcc42.name" value="gcc-4.2"/>		<condition property="gcc" value="${gcc42.name}" else="${gcc.name}">			<isset property="gcc42.name" />		</condition>		<!-- Ask Xcode for correct path to XCode tools -->		<!-- Will fail if XCode Command Line Tools are not installed on 10.7+ (Lion) -->		<exec executable="xcode-select" outputproperty="developer_path" errorproperty="xcode-select.error" failonerror="false" failifexecutionfails="false">			<arg value="-print-path" />		</exec>		<!-- Default to /Developer if xcode-select fails -->		<condition property="developer_path" value="/Developer">			<isset property="xcode-select.error" />		</condition>		<!-- Detect Mac OS X 10.7 SDK in new Xcode path for for Mac OS  10.7+ -->		<condition property="sdk-10.7" value="${developer_path}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk">			<available file="${developer_path}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk" type="dir"/>		</condition>		<condition property="javavm-10.7" value="${developer_path}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk">			<available file="${developer_path}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk/System/Library/Frameworks/JavaVM.framework/Versions/A/Headers" type="dir"/>		</condition>		<!-- Detect Mac OS X 10.6 SDK copied into new Xcode path for Mac OS  10.7+ -->		<condition property="sdk-10.6" value="${developer_path}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.6.sdk">			<available file="${developer_path}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.6.sdk" type="dir"/>		</condition>		<condition property="javavm-10.6" value="${developer_path}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.6.sdk">			<available file="${developer_path}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.6.sdk/System/Library/Frameworks/JavaVM.framework/Versions/A/Headers" type="dir"/>		</condition>		<!-- Detect Mac OS X 10.6 SDK in old XCode location for Mac OS 10.6 -->		<condition property="old.sdk-10.6" value="${developer_path}/SDKs/MacOSx10.6.sdk">			<available file="${developer_path}/SDKs/MacOSx10.6.sdk" type="dir"/>		</condition>		<condition property="old.javavm-10.6" value="">			<available file="/System/Library/Frameworks/JavaVM.framework/Versions/A/Headers" type="dir"/>		</condition>		<!-- Use old JavaVM.framework location if nothing else is available -->		<condition property="javavmroot" value="${old.javavm-10.6}">			<and>				<isset property="old.javavm-10.6" />				<not>					<or>						<isset property="javavm-10.6" />						<isset property="javavm-10.7" />					</or>				</not>			</and>		</condition>		<!-- Use JavaVM.framework from 10.6 in new Xcode path if available -->		<condition property="javavmroot" value="${javavm-10.6}">			<isset property="javavm-10.6" />		</condition>		<!-- Use JavaVM.framework from 10.7 in new Xcode path if available and 10.6 isn't also there -->		<condition property="javavmroot" value="${javavm-10.7}">			<and>				<isset property="javavm-10.7" />				<not>					<isset property="javavm-10.6" />				</not>			</and>		</condition>		<!-- Use MacOS SDK 10.6 from /Developer if nothing else is available -->		<condition property="sdkroot" value="${old.sdk-10.6}">			<and>				<isset property="old.sdk-10.6" />				<not>					<or>						<isset property="sdk-10.6" />						<isset property="sdk-10.7" />					</or>				</not>			</and>		</condition>		<!-- Use MacOS SDK 10.6 from new Xcode location if available -->		<condition property="sdkroot" value="${sdk-10.6}">			<isset property="sdk-10.6" />		</condition>		<!-- Use MacOS SDK 10.7 in new Xcode path if available and 10.6 SDK isn't also there -->		<condition property="sdkroot" value="${sdk-10.7}">			<and>				<isset property="sdk-10.7" />				<not>					<isset property="sdk-10.6" />				</not>			</and>		</condition>	</target>	<target name="clean">		<delete failonerror="false">			<fileset dir="i386"/>			<fileset dir="x86_64"/>			<fileset dir="." includes="liblwjgl.jnilib"/>			<fileset dir="." includes="lwjgl.symbols"/>		</delete>	</target>	<target name="compile" depends="init">		<apply dir="${dstdir}" executable="${compiler}" os="Mac OS X" skipemptyfilesets="true" failonerror="true" dest="${dstdir}">			<arg line="${cflags} -ObjC -O2 -Wall -Wunused -c -fPIC -I${javavmroot}/System/Library/Frameworks/JavaVM.framework/Versions/A/Headers -I${native}/common -I${native}/common/opengl -I${native}/macosx"/>			<!-- Map from *.m and *.c to .o -->			<mapper type="regexp" from="^(.*)\.(c|m)" to="\1.o"/>			<fileset dir="${native}/macosx" includes="*.m"/>			<fileset dir="${native}/macosx" includes="*.c"/>			<fileset dir="${native}/common" includes="*.c"/>			<fileset dir="${native}/common/opengl" includes="*.c"/>			<fileset dir="${native}/generated/openal" includes="*.c"/>			<fileset dir="${native}/generated/opencl" includes="*.c"/>			<fileset dir="${native}/generated/opengl" includes="*.c"/>		</apply>	</target>	<target name="link" depends="init">		<apply dir="${objdir}" parallel="true" executable="${linker}" os="Mac OS X" failonerror="true" skipemptyfilesets="true">			<arg line="${linkerflags} -exported_symbols_list ../lwjgl.symbols -dynamiclib -o ${libname} -framework Foundation -weak_framework AppKit -framework Carbon -framework OpenGL -framework QuartzCore -L${java.home}/../Libraries -ljawt"/>			<fileset dir="${objdir}" includes="*.o"/>		</apply>		<apply dir="${objdir}" executable="strip" os="Mac OS X" failonerror="true">			<arg line="-S -X"/>			<fileset dir="." file="${libname}"/>		</apply>	</target>	<target name="nativelibrary" depends="init">		<echo message="             GCC: ${gcc}"/>		<echo message="      Mac OS SDK: ${sdkroot}"/>		<echo message="JavaVM.framework: ${javavmroot}"/>		<property name="universal_sdkroot" location="${sdkroot}"/>		<property name="x86_64_sdkroot" location="${sdkroot}"/>		<property name="universal_flags" value="-isysroot ${universal_sdkroot}"/>		<antcall target="compile">			<param name="dstdir" location="i386"/>			<param name="compiler" value="${gcc}"/>			<param name="sdkroot" location="${universal_sdkroot}"/>			<param name="cflags" value="${universal_flags} -arch i386 -mmacosx-version-min=10.5"/>		</antcall>		<antcall target="compile">			<param name="dstdir" location="x86_64"/>			<param name="compiler" value="${gcc}"/>			<param name="sdkroot" location="${universal_sdkroot}"/>			<param name="cflags" value="-isysroot ${x86_64_sdkroot} -arch x86_64 -mmacosx-version-min=10.5"/>		</antcall>		<exec vmlauncher="true" executable="sh" output="lwjgl.symbols" failonerror="true">			<arg path="../../platform_build/macosx_ant/build-symbol-list"/>			<arg path="i386"/>		</exec>		<antcall target="link">			<param name="objdir" location="i386"/>			<param name="libname" value="liblwjgl-i386.jnilib"/>			<param name="linker" value="${gcc}"/>			<param name="linkerflags" value="${universal_flags} -arch i386 -mmacosx-version-min=10.5"/>		</antcall>		<antcall target="link">			<param name="objdir" location="x86_64"/>			<param name="libname" value="liblwjgl-i86_64.jnilib"/>			<param name="linker" value="${gcc}"/>			<param name="linkerflags" value="-isysroot ${x86_64_sdkroot} -arch x86_64 -mmacosx-version-min=10.5"/>		</antcall>		<apply dir="." parallel="true" executable="lipo" os="Mac OS X" failonerror="true" skipemptyfilesets="true" >			<arg value="-create"/>			<srcfile/>			<arg value="-output"/>			<arg path="liblwjgl.jnilib"/>			<fileset file="i386/liblwjgl-i386.jnilib"/>			<fileset file="x86_64/liblwjgl-i86_64.jnilib"/>		</apply>	</target></project>
+
+<project name="OS X Native code" basedir="../../bin/lwjgl" default="nativelibrary">
+	<property name="native" location="../../src/native"/>
+
+	<target name="init">
+		<mkdir dir="i386"/>
+		<mkdir dir="x86_64"/>
+		<property environment="env" />
+		<!-- Check which gcc we have, newer releasse of Mac OS do not have gcc-4.2 installed by defaault -->
+		<available file="gcc" filepath="${env.PATH}" property="gcc.name" value="gcc"/>
+		<available file="gcc-4.2" filepath="${env.PATH}" property="gcc42.name" value="gcc-4.2"/>
+		<condition property="gcc" value="${gcc42.name}" else="${gcc.name}">
+			<isset property="gcc42.name" />
+		</condition>
+		<!-- Ask Xcode for correct path to XCode tools -->
+		<!-- Will fail if XCode Command Line Tools are not installed on 10.7+ (Lion) -->
+		<exec executable="xcode-select" outputproperty="developer_path" errorproperty="xcode-select.error" failonerror="false" failifexecutionfails="false">
+			<arg value="-print-path" />
+		</exec>
+		<!-- Default to /Developer if xcode-select fails -->
+		<condition property="developer_path" value="/Developer">
+			<isset property="xcode-select.error" />
+		</condition>
+		<!-- Detect Mac OS X 10.7 SDK in new Xcode path for for Mac OS  10.7+ -->
+		<condition property="sdk-10.7" value="${developer_path}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk">
+			<available file="${developer_path}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk" type="dir"/>
+		</condition>
+		<condition property="javavm-10.7" value="${developer_path}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk">
+			<available file="${developer_path}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk/System/Library/Frameworks/JavaVM.framework/Versions/A/Headers" type="dir"/>
+		</condition>
+		<!-- Detect Mac OS X 10.6 SDK copied into new Xcode path for Mac OS  10.7+ -->
+		<condition property="sdk-10.6" value="${developer_path}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.6.sdk">
+			<available file="${developer_path}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.6.sdk" type="dir"/>
+		</condition>
+		<condition property="javavm-10.6" value="${developer_path}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.6.sdk">
+			<available file="${developer_path}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.6.sdk/System/Library/Frameworks/JavaVM.framework/Versions/A/Headers" type="dir"/>
+		</condition>
+		<!-- Detect Mac OS X 10.6 SDK in old XCode location for Mac OS 10.6 -->
+		<condition property="old.sdk-10.6" value="${developer_path}/SDKs/MacOSx10.6.sdk">
+			<available file="${developer_path}/SDKs/MacOSx10.6.sdk" type="dir"/>
+		</condition>
+		<condition property="old.javavm-10.6" value="">
+			<available file="/System/Library/Frameworks/JavaVM.framework/Versions/A/Headers" type="dir"/>
+		</condition>
+		<!-- Use old JavaVM.framework location if nothing else is available -->
+		<condition property="javavmroot" value="${old.javavm-10.6}">
+			<and>
+				<isset property="old.javavm-10.6" />
+				<not>
+					<or>
+						<isset property="javavm-10.6" />
+						<isset property="javavm-10.7" />
+					</or>
+				</not>
+			</and>
+		</condition>
+		<!-- Use JavaVM.framework from 10.6 in new Xcode path if available -->
+		<condition property="javavmroot" value="${javavm-10.6}">
+			<isset property="javavm-10.6" />
+		</condition>
+		<!-- Use JavaVM.framework from 10.7 in new Xcode path if available and 10.6 isn't also there -->
+		<condition property="javavmroot" value="${javavm-10.7}">
+			<and>
+				<isset property="javavm-10.7" />
+				<not>
+					<isset property="javavm-10.6" />
+				</not>
+			</and>
+		</condition>
+		<!-- Use MacOS SDK 10.6 from /Developer if nothing else is available -->
+		<condition property="sdkroot" value="${old.sdk-10.6}">
+			<and>
+				<isset property="old.sdk-10.6" />
+				<not>
+					<or>
+						<isset property="sdk-10.6" />
+						<isset property="sdk-10.7" />
+					</or>
+				</not>
+			</and>
+		</condition>
+		<!-- Use MacOS SDK 10.6 from new Xcode location if available -->
+		<condition property="sdkroot" value="${sdk-10.6}">
+			<isset property="sdk-10.6" />
+		</condition>
+		<!-- Use MacOS SDK 10.7 in new Xcode path if available and 10.6 SDK isn't also there -->
+		<condition property="sdkroot" value="${sdk-10.7}">
+			<and>
+				<isset property="sdk-10.7" />
+				<not>
+					<isset property="sdk-10.6" />
+				</not>
+			</and>
+		</condition>
+	</target>
+
+	<target name="clean">
+		<delete failonerror="false">
+			<fileset dir="i386"/>
+			<fileset dir="x86_64"/>
+			<fileset dir="." includes="liblwjgl.jnilib"/>
+			<fileset dir="." includes="lwjgl.symbols"/>
+		</delete>
+	</target>
+
+	<target name="compile" depends="init">
+		<apply dir="${dstdir}" executable="${compiler}" os="Mac OS X" skipemptyfilesets="true" failonerror="true" dest="${dstdir}">
+			<arg line="${cflags} -ObjC -O2 -Wall -Wunused -c -fPIC -I${javavmroot}/System/Library/Frameworks/JavaVM.framework/Versions/A/Headers -I${native}/common -I${native}/common/opengl -I${native}/macosx"/>
+			<!-- Map from *.m and *.c to .o -->
+			<mapper type="regexp" from="^(.*)\.(c|m)" to="\1.o"/>
+			<fileset dir="${native}/macosx" includes="*.m"/>
+			<fileset dir="${native}/macosx" includes="*.c"/>
+			<fileset dir="${native}/common" includes="*.c"/>
+			<fileset dir="${native}/common/opengl" includes="*.c"/>
+			<fileset dir="${native}/generated/openal" includes="*.c"/>
+			<fileset dir="${native}/generated/opencl" includes="*.c"/>
+			<fileset dir="${native}/generated/opengl" includes="*.c"/>
+		</apply>
+	</target>
+
+	<target name="link" depends="init">
+		<apply dir="${objdir}" parallel="true" executable="${linker}" os="Mac OS X" failonerror="true" skipemptyfilesets="true">
+			<arg line="${linkerflags} -exported_symbols_list ../lwjgl.symbols -dynamiclib -o ${libname} -framework Foundation -weak_framework AppKit -framework Carbon -framework OpenGL -framework QuartzCore -L${java.home}/../Libraries -ljawt"/>
+			<fileset dir="${objdir}" includes="*.o"/>
+		</apply>
+		<apply dir="${objdir}" executable="strip" os="Mac OS X" failonerror="true">
+			<arg line="-S -X"/>
+			<fileset dir="." file="${libname}"/>
+		</apply>
+	</target>
+
+	<target name="nativelibrary" depends="init">
+		<echo message="             GCC: ${gcc}"/>
+		<echo message="      Mac OS SDK: ${sdkroot}"/>
+		<echo message="JavaVM.framework: ${javavmroot}"/>
+		<property name="universal_sdkroot" location="${sdkroot}"/>
+		<property name="x86_64_sdkroot" location="${sdkroot}"/>
+		<property name="universal_flags" value="-isysroot ${universal_sdkroot}"/>
+		<antcall target="compile">
+			<param name="dstdir" location="i386"/>
+			<param name="compiler" value="${gcc}"/>
+			<param name="sdkroot" location="${universal_sdkroot}"/>
+			<param name="cflags" value="${universal_flags} -arch i386 -mmacosx-version-min=10.5"/>
+		</antcall>
+		<antcall target="compile">
+			<param name="dstdir" location="x86_64"/>
+			<param name="compiler" value="${gcc}"/>
+			<param name="sdkroot" location="${universal_sdkroot}"/>
+			<param name="cflags" value="-isysroot ${x86_64_sdkroot} -arch x86_64 -mmacosx-version-min=10.5"/>
+		</antcall>
+		<exec vmlauncher="true" executable="sh" output="lwjgl.symbols" failonerror="true">
+			<arg path="../../platform_build/macosx_ant/build-symbol-list"/>
+			<arg path="i386"/>
+		</exec>
+		<antcall target="link">
+			<param name="objdir" location="i386"/>
+			<param name="libname" value="liblwjgl-i386.jnilib"/>
+			<param name="linker" value="${gcc}"/>
+			<param name="linkerflags" value="${universal_flags} -arch i386 -mmacosx-version-min=10.5"/>
+		</antcall>
+		<antcall target="link">
+			<param name="objdir" location="x86_64"/>
+			<param name="libname" value="liblwjgl-i86_64.jnilib"/>
+			<param name="linker" value="${gcc}"/>
+			<param name="linkerflags" value="-isysroot ${x86_64_sdkroot} -arch x86_64 -mmacosx-version-min=10.5"/>
+		</antcall>
+		<apply dir="." parallel="true" executable="lipo" os="Mac OS X" failonerror="true" skipemptyfilesets="true" >
+			<arg value="-create"/>
+			<srcfile/>
+			<arg value="-output"/>
+			<arg path="liblwjgl.jnilib"/>
+			<fileset file="i386/liblwjgl-i386.jnilib"/>
+			<fileset file="x86_64/liblwjgl-i86_64.jnilib"/>
+		</apply>
+	</target>
+</project>


### PR DESCRIPTION
While using `grep` to search through the source files on a Mac, I noticed that `platform_build/macosx_ant/build.xml` had carriage returns between each line instead of line feeds. This made the output hard to read. I changed each of the carriage returns in the file to be line feeds.
