### PR TITLE
Mac OS X: fix custom mouse cursor image

### DIFF
--- a/src/native/macosx/org_lwjgl_opengl_MacOSXNativeMouse.m
+++ b/src/native/macosx/org_lwjgl_opengl_MacOSXNativeMouse.m
@@ -127,7 +127,7 @@ JNIEXPORT jlong JNICALL Java_org_lwjgl_opengl_MacOSXNativeMouse_nCreateCursor(JN
 	jlong *bytes = (jint *)(*env)->GetDirectBufferAddress(env, image_buffer) + images_offset;
 	
 	NSBitmapImageRep *bitmap = [[[NSBitmapImageRep alloc]
-								initWithBitmapDataPlanes:(jlong *)&bytes
+								initWithBitmapDataPlanes:NULL
 								pixelsWide:width pixelsHigh:height
 								bitsPerSample:8
 								samplesPerPixel:4
@@ -137,6 +137,7 @@ JNIEXPORT jlong JNICALL Java_org_lwjgl_opengl_MacOSXNativeMouse_nCreateCursor(JN
 								bitmapFormat:NSAlphaNonpremultipliedBitmapFormat
 								bytesPerRow:width*4
 								bitsPerPixel:32] autorelease];
+	memcpy((void*)bitmap.bitmapData, (void*)bytes, width*height*4);
 	
 	NSImage *image = [[[NSImage alloc] initWithSize:NSMakeSize(width, height)] autorelease];
 	


### PR DESCRIPTION
According to
https://developer.apple.com/library/mac/#documentation/Cocoa/Reference/ApplicationKit/Classes/nsbitmapimagerep_Class/Reference/Reference.html
the data referenced by the "planes" parameter will not be copied into
the NSBitmapImageRep class.

This means that when the referenced data changes (which is very likely
in our case since the data is retrieved from Java by
GetDirectBufferAddress()) we see exactly the effect described in the
LWJGL forum here: http://lwjgl.org/forum/index.php/topic,5007.0.html

The Apple class reference documentation linked above also describes
that when the "planes" parameter is NULL then the NSBitmapImageRep
class will allocate enough memory to store the image data and will
automatically free the allocated memory when the NSBitmapImageRep
instance is freed. In this case the data can be accessed with the
"bitmapData" method.

Which is exactly what we'll do now: pass NULL into the method to let it
allocate memory and then simply memcpy our image data into that area.

This seems to fix the mouse cursor image.
