### PR TITLE
Modified browser launchers in Linux Sys.openURL method

### DIFF
--- a/src/java/org/lwjgl/LinuxSysImplementation.java
+++ b/src/java/org/lwjgl/LinuxSysImplementation.java
@@ -71,7 +71,7 @@ final class LinuxSysImplementation extends J2SESysImplementation {
 		// Linux may as well resort to pure Java hackery, as there's no Linux native way of doing it
 		// right anyway.
 
-		String[] browsers = {"xdg-open", "firefox", "mozilla", "opera", "konqueror", "nautilus", "galeon", "netscape"};
+		String[] browsers = {"sensible-browser", "xdg-open", "google-chrome", "chromium", "firefox", "iceweasel", "mozilla", "opera", "konqueror", "nautilus", "galeon", "netscape"};
 
 		for ( final String browser : browsers ) {
 			try {


### PR DESCRIPTION
Added "sensible-browser" as the first browser launcher option, even before xdg-open.
sensible-browser tries to open an URL using the preferred web browser, while xdg-open just to open a resource (not just an URL) with the preferred application.
Since the method is called openURL and a URL (Uniform Resource Locator) is a web address, sensible-browser fits the functionality better.
A notable difference would be calling Sys.openURL('localhost').
Since "localhost" has no leading "http://", xdg-open would try to open a "localhost" file and fail, while sensible-browser would launch the appropriate browser.

While sensible-browser is particular of Debian-based systems and is not as common as xdg-open, this does not negatively affect systems that do not have sensible-browser:
Were it not present in the system, the rest of the browser launchers would be tried, starting by xdg-open.

Added "iceweasel" after "firefox". Iceweasel is the Debian fork of Firefox.

Added "google-chrome" and "chromium". Chromium is provided in Debian instead of Google Chrome.
Since the stats in http://www.w3schools.com/browsers/browsers_stats.asp show that Google Chrome is used by more users than Firefox, I put both Google Chrome and Chromium before Firefox in the list.
This change will not affect most of the users, as they will have a preferred browser set up with either sensible-browser or xdg-open.
