### PR TITLE
wrong log message LWJGLUtil.java

### DIFF
--- a/src/java/org/lwjgl/LWJGLUtil.java
+++ b/src/java/org/lwjgl/LWJGLUtil.java
@@ -440,7 +440,7 @@ public class LWJGLUtil {
 				}
 			}
 		} catch (Exception e) {
-			log("Failure locating " + e + " using classloader:" + e);
+			log("Failure locating " + e + " using classloader:" + c);
 		}
 		return null;
 	}


### PR DESCRIPTION
Im trying to debug a error while loading lwjgl binaries but i get a strange message.
[LWJGL] Failure locating java.lang.NoSuchMethodException: findLibrary using classloader:java.lang.NoSuchMethodException: findLibrary

I guess it's a typo c instead of e again.
