### PR TITLE
Fix util applet permissions

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -162,7 +162,7 @@
 				<attribute name="Permissions" value="all-permissions"/>
 				<attribute name="Codebase" value="*"/>
 				<attribute name="Caller-Allowable-Codebase" value="*"/>
-				<attribute name="Application-Library-Allowable-Codebase" value="true"/>
+				<attribute name="Application-Library-Allowable-Codebase" value="*"/>
 			</manifest>
 		</jar>
 


### PR DESCRIPTION
According to the specs, the `Application-Library-Allowable-Codebase` attribute identifies locations (similar to the other codebase attributes). The JRE therefore thinks that "true" was a folder name (I guess).

I manually updated all MANIFEST.MF files by replacing `true` with `*` and resigned them. The jars now work for me with Java7u54.

EDIT: here's the direct link:
http://docs.oracle.com/javase/8/docs/technotes/guides/jweb/security/manifest.html#app_library
