### PR TITLE
Fix some straightforward Javadoc problems

### DIFF
--- a/src/java/org/lwjgl/LWJGLUtil.java
+++ b/src/java/org/lwjgl/LWJGLUtil.java
@@ -605,7 +605,7 @@ public class LWJGLUtil {
 		 * @param field the Field to test
 		 * @param value the integer value of the field
 		 *
-		 * @result true if the Field is accepted
+		 * @return true if the Field is accepted
 		 */
 		boolean accept(Field field, int value);
 

--- a/src/java/org/lwjgl/openal/ALCcontext.java
+++ b/src/java/org/lwjgl/openal/ALCcontext.java
@@ -82,7 +82,7 @@ public final class ALCcontext {
 	 * @param contextFrequency Frequency to add
 	 * @param contextRefresh Refresh rate to add
 	 * @param contextSynchronized Whether to synchronize the context
-	 * @return
+	 * @return attribute list
 	 */
 	static IntBuffer createAttributeList(int contextFrequency, int contextRefresh, int contextSynchronized) {
 		IntBuffer attribList = BufferUtils.createIntBuffer(7);

--- a/src/java/org/lwjgl/util/applet/AppletLoader.java
+++ b/src/java/org/lwjgl/util/applet/AppletLoader.java
@@ -1867,8 +1867,8 @@ public class AppletLoader extends Applet implements Runnable, AppletStub {
 	/**
 	 * Compare two certificate chains to see if they match
 	 *
-	 * @param cert1 first chain of certificates
-	 * @param cert2 second chain of certificates
+	 * @param certs1 first chain of certificates
+	 * @param certs2 second chain of certificates
 	 * 
 	 * @return true if the certificate chains are the same
 	 */
@@ -2224,7 +2224,7 @@ public class AppletLoader extends Applet implements Runnable, AppletStub {
 
 	/** 
 	 * set the state of applet loader 
-	 * @param new state of applet loader
+	 * @param state new state of applet loader
 	 * */
 	protected void setState(int state) {
 		this.state = state;

--- a/src/java/org/lwjgl/util/glu/Project.java
+++ b/src/java/org/lwjgl/util/glu/Project.java
@@ -98,7 +98,7 @@ public class Project extends Util {
 	 * @param src
 	 * @param inverse
 	 *
-	 * @return
+	 * @return true if the matrix was succesfully inverted
 	 */
 	private static boolean __gluInvertMatrixf(FloatBuffer src, FloatBuffer inverse) {
 		int i, j, k, swap;

--- a/src/java/org/lwjgl/util/mapped/CacheLinePad.java
+++ b/src/java/org/lwjgl/util/mapped/CacheLinePad.java
@@ -52,14 +52,14 @@ public @interface CacheLinePad {
 	/**
 	 * When true, cache-line padding will be inserted before the field.
 	 *
-	 * @return
+	 * @return true if cache-line padding will be inserted before the field
 	 */
 	boolean before() default false;
 
 	/**
 	 * When true, cache-line padding will be inserted after the field.
 	 *
-	 * @return
+	 * @return true if cache-line padding will be inserted after the field
 	 */
 	boolean after() default true;
 


### PR DESCRIPTION
I've fixed some of the more straightforward Javadoc output warnings.

There's still lots of warnings - some for links to dependent libraries (e.g. opengl, asm). But I thought I'd send a pull request the more trivial ones first and then try and work out if the others can be practically fixed.
