### PR TITLE
linux: do not release context for gallium amd driver

### DIFF
--- a/src/java/org/lwjgl/opengl/ContextGL.java
+++ b/src/java/org/lwjgl/opengl/ContextGL.java
@@ -253,8 +253,12 @@ final class ContextGL implements Context {
 		boolean was_current = isCurrent();
 		int error = GL_NO_ERROR;
 		if ( was_current ) {
-			if ( GLContext.getCapabilities() != null && GLContext.getCapabilities().OpenGL11 )
-				error = glGetError();
+                        try {
+                                if ( GLContext.getCapabilities().OpenGL11 )
+                                        error = glGetError();
+                        } catch (RuntimeException ex) {
+                            // this happens instead of getCapabilites() returning null, ignore
+                        }
 			releaseCurrent();
 		}
 		checkDestroy();

--- a/src/java/org/lwjgl/opengl/LinuxContextImplementation.java
+++ b/src/java/org/lwjgl/opengl/LinuxContextImplementation.java
@@ -89,6 +89,11 @@ final class LinuxContextImplementation implements ContextImplementation {
 	private static native void nSwapBuffers(ByteBuffer peer_info_handle) throws LWJGLException;
 
 	public void releaseCurrentContext() throws LWJGLException {
+                // do not release context for gallium3D amd driver, see MC-70651
+                String renderer = GL11.glGetString(GL11.GL_RENDERER).toLowerCase();
+                if (renderer.contains("gallium") && (renderer.contains("amd") || renderer.contains("ati"))) {
+                    return;
+                }
 		ContextGL current_context = ContextGL.getCurrentContext();
 		if ( current_context == null )
 			throw new IllegalStateException("No context is current");


### PR DESCRIPTION
This is the second of two fixes related to [MC-70651](https://bugs.mojang.com/browse/MC-70651).
I created two PRs for this because one patch is just a fix for lwjgl, the other one a workaround for dubious driver behavior.

This is the second one, which contains a workaround for the gallium radeon driver for amd cards.

The whole story can be found in the minecraft bugtracker linked above.
Long story short, the driver sometimes fails to re-create the window when switching to fullscreen.

The exact reason for this is unknown. During my research, I came across some old commits like 9aefad3f09b15a43ac2a29ea53628f1bd11a2d70. This pointed me in the right direction. I toyed around with the way the window is destroyed and noticed the problem goes away if releaseDrawable() is never called in Display.

I also tried changing the order of destroyWindow(), releaseDrawable() etc but this did not help. The problem only goes away if releaseDrawable() is completely removed.

This patch is the best solution I came up with, but I'm not 100% sure if it should be merged like this. There are two changes here:
1. The main fix. I tried to avoid harming other (working) platforms and drivers as much as possible, so I left Display alone and moved this fix to linux specific code. This checks if the problematic driver is in use and then just skips releasing the context.
2. The main fix creates a minor problem: ContextGL crashes in destroy() because the context has not been released correctly. (This only occurs when closing the application). In this case, GLContext.getCapabilities() throws an Exception. However, destroy() contains a non-null-check that can never be triggered because getCapabilities() never returns null. I suspect this was changed in b824d786c4f7fe4db6263433dc2cec6407694bb8 but the code in ContextGL was never updated. So I converted the non-null-check to a try-catch.
