### PR TITLE
EXT_cg_shader letter-case is wrong (uppercase) and prevents compile task...

### DIFF
--- a/src/templates/org/lwjgl/opengl/EXT_cg_shader.java
+++ b/src/templates/org/lwjgl/opengl/EXT_cg_shader.java
@@ -31,7 +31,7 @@
  */
 package org.lwjgl.opengl;
 
-public interface EXT_Cg_shader {
+public interface EXT_cg_shader {
 
 	/**
 	 * You can pass GL_CG_VERTEX_SHADER_EXT to glCreateShaderARB instead of GL_VERTEX_SHADER_ARB to create a vertex shader object


### PR DESCRIPTION
Found an issue on compile time with a template file : EXT_cg_shader.java which denotes an incorrectly named EXT_Cg_shader interface, that is case-sensitive.
