### PR TITLE
Finally fix support for OpenBSD

### DIFF
--- a/src/native/linux/opengl/extgl_glx.c
+++ b/src/native/linux/opengl/extgl_glx.c
@@ -220,7 +220,11 @@ bool extgl_Open(JNIEnv *env) {
 	 *
 	 * DRI drivers need this flag to work properly
 	 */
+#ifdef __OpenBSD__
+	lib_gl_handle = dlopen("libGL.so", RTLD_LAZY | RTLD_GLOBAL);
+#else
 	lib_gl_handle = dlopen("libGL.so.1", RTLD_LAZY | RTLD_GLOBAL);
+#endif
 	if (lib_gl_handle == NULL) {
 		throwFormattedException(env, "Error loading libGL.so.1: %s", dlerror());
 		return false;


### PR DESCRIPTION
This pull request is the last (missing) code from:
https://github.com/LWJGL/lwjgl/pull/54

It completes OpenBSD support, and avoids creating an ugly symbolic link to the "missing" library.

After this patch, lwjgl successfully runs in OpenBSD 5.5. And it also fixes Minecraft and jPCT in that platform.

Original discussion:
https://github.com/chessgriffin/obsd-minecraft/issues/1
