### PR TITLE
WindowsKeyboard.releaseAll() needs current event time

### DIFF
--- a/src/java/org/lwjgl/opengl/WindowsDisplay.java
+++ b/src/java/org/lwjgl/opengl/WindowsDisplay.java
@@ -381,7 +381,7 @@ final class WindowsDisplay implements DisplayImplementation {
 				updateClipping();
 		} else {
 			if ( keyboard != null )
-				keyboard.releaseAll(millis);
+				keyboard.releaseAll(System.currentTimeMillis());
 			if ( Display.isFullscreen() ) {
 				showWindow(getHwnd(), SW_SHOWMINNOACTIVE);
 				resetDisplayMode();


### PR DESCRIPTION
Since the last update no variable "millis" found and fails to compile. I suggest to insert the current time milliseconds in the event. 