### PR TITLE
Fix a `java.lang.NullPointerException`.

### DIFF
--- a/src/java/org/lwjgl/opengl/LinuxContextImplementation.java
+++ b/src/java/org/lwjgl/opengl/LinuxContextImplementation.java
@@ -143,10 +143,12 @@ final class LinuxContextImplementation implements ContextImplementation {
 
 	public void setSwapInterval(int value) {
 		ContextGL current_context = ContextGL.getCurrentContext();
-		PeerInfo peer_info = current_context.getPeerInfo();
 		
 		if ( current_context == null )
 			throw new IllegalStateException("No context is current");
+		
+		PeerInfo peer_info = current_context.getPeerInfo();
+		
 		synchronized ( current_context ) {
 			LinuxDisplay.lockAWT();
 			try {


### PR DESCRIPTION
If not context is found, a `NullPointerException` was thrown, and not the `IllegalStateException`.
```
java.lang.NullPointerException
	at org.lwjgl.opengl.LinuxContextImplementation.setSwapInterval(LinuxContextImplementation.java:146)
```