### PR TITLE
One doc improvement, two bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ Compilation
 
 LWJGL requires a JDK and Ant installed to compile, as well as your platforms native compiler to compile the JNI.
 
+To build all:
+
+* ant all
+
+Or for finer control on what's done:
+
 * ant generate-all
 * ant compile
 * ant compile_native
+* ant jars

--- a/platform_build/build-generator.xml
+++ b/platform_build/build-generator.xml
@@ -17,6 +17,7 @@
 
 	<!-- Compiles the Java generator source code -->
 	<target name="generators" description="Compiles the native method generators">            
+        <mkdir dir="${lwjgl.bin}/"/>
         <mkdir dir="${lwjgl.src}/generated/"/>
         <mkdir dir="${lwjgl.src.native}/generated/openal"/>
         <mkdir dir="${lwjgl.src.native}/generated/opengl"/>

--- a/src/java/org/lwjgl/opengl/XRandR.java
+++ b/src/java/org/lwjgl/opengl/XRandR.java
@@ -259,7 +259,7 @@ public class XRandR {
 	}
 
 	private static final Pattern SCREEN_HEADER_PATTERN   = Pattern.compile("^(\\d+)x(\\d+)[+](\\d+)[+](\\d+)$");
-	private static final Pattern SCREEN_MODELINE_PATTERN = Pattern.compile("^(\\d+)x(\\d+)$");
+	private static final Pattern SCREEN_MODELINE_PATTERN = Pattern.compile("^(\\d+)x(\\d+)(_[0-9.]+)?$");
 	private static final Pattern FREQ_PATTERN            = Pattern.compile("^(\\d+)[.](\\d+)(?:\\s*[*])?(?:\\s*[+])?$");
 
 	/**


### PR DESCRIPTION
Three changes:
* For anyone not familiar with ant, add a hin to "ant all" and "ant jars" in readme
* Create directory bin (build actually fails otherwise on a fresh clone).
* Allow XRandR Modelines like "1920x1200_50.00 [...]" to be parsed.