### PR TITLE
Add mkdir bin to build-generator.xml

### DIFF
--- a/platform_build/build-generator.xml
+++ b/platform_build/build-generator.xml
@@ -22,6 +22,7 @@
         <mkdir dir="${lwjgl.src.native}/generated/opengl"/>
         <mkdir dir="${lwjgl.src.native}/generated/opengles"/>
         <mkdir dir="${lwjgl.src.native}/generated/opencl"/>
+        <mkdir dir="${lwjgl.bin}"/>
 
 		<javac debug="yes" srcdir="${lwjgl.src}/java/" destdir="${lwjgl.bin}" source="1.6" target="1.6" includes="org/lwjgl/util/generator/**.java" taskname="generator">
             <include name="org/lwjgl/util/generator/openal/**.java"/>


### PR DESCRIPTION
From a `git clone` trying to `ant generate-all` on Ubuntu Linux on Odroid XU4 I got the error:  
`lwjgl/platform_build/build-generator.xml:26 destination directory  lgwjgl/bin` does exist or is not a directory.

