### PR TITLE
Force using high performance GPU for AMD Switchable Graphics

### DIFF
--- a/src/native/windows/LWJGL.c
+++ b/src/native/windows/LWJGL.c
@@ -48,6 +48,7 @@
 HINSTANCE dll_handle;
 
 __declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001; // Force high performance GPU for Nvidia Optimus systems
+__declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1; // Force high performance GPU for AMD systems
 
 /*
  * DLL entry point for Windows. Called when Java loads the .dll


### PR DESCRIPTION
This is based on similar changes published elsewhere.

See:
https://community.amd.com/thread/169965
https://github.com/glfw/glfw/commit/6d5753c54863877020a4f3d12960e417fb04824b
