### PR TITLE
Support for cvt modeline output

### DIFF
--- a/src/java/org/lwjgl/opengl/XRandR.java
+++ b/src/java/org/lwjgl/opengl/XRandR.java
@@ -262,7 +262,7 @@ public class XRandR {
 	}
 
 	private static final Pattern SCREEN_HEADER_PATTERN   = Pattern.compile("^(\\d+)x(\\d+)[+](\\d+)[+](\\d+)$");
-	private static final Pattern SCREEN_MODELINE_PATTERN = Pattern.compile("^(\\d+)x(\\d+)$");
+	private static final Pattern SCREEN_MODELINE_PATTERN = Pattern.compile("^(\d+)x(\d+)(_\d+\.\d+)?$");
 	private static final Pattern FREQ_PATTERN            = Pattern.compile("^(\\d+[.]\\d+)(?:\\s*[*])?(?:\\s*[+])?$");
 
 	/**


### PR DESCRIPTION
https://wiki.archlinux.org/index.php/xrandr#Troubleshooting ctv tool generates display modes as 1280x1024_60.00 instead of 1280x1024

$ cvt 1280 1024
 1280x1024 59.89 Hz (CVT 1.31M4) hsync: 63.67 kHz; pclk: 109.00 MHz
Modeline "**1280x1024_60.00**"  109.00  1280 1368 1496 1712  1024 1027 1034 1063 -hsync +vsync