### PR TITLE
Fixed NullPointerException w/ virtual displays

### DIFF
--- a/src/java/org/lwjgl/opengl/LinuxDisplay.java
+++ b/src/java/org/lwjgl/opengl/LinuxDisplay.java
@@ -943,7 +943,7 @@ final class LinuxDisplay implements DisplayImplementation {
                                 // nGetAvailableDisplayModes cannot be trusted. Use it only for bitsPerPixel
                                 DisplayMode[] nDisplayModes = nGetAvailableDisplayModes(getDisplay(), getDefaultScreen(), current_displaymode_extension);
                                 int bpp = 24;
-                                if (nDisplayModes.length > 0) {
+                                if (nDisplayModes != null && nDisplayModes.length > 0) {
                                     bpp = nDisplayModes[0].getBitsPerPixel();
                                 }
                                 // get the resolutions and frequencys from XRandR


### PR DESCRIPTION
Fixed a NullPointerException caused by trying to call `getAvailableDisplayModes`
when the user has a virtual display.
LWJGL tries to get the bits per pixel of the display, nGetAvailableDisplayModes returns null,
then the length check causes a NullPointerException on line 950.

And yes, I know LWJGL2 is legacy but LibGDX still uses it and I like LibGDX so i'm not switching to LWJGL3!

Edit:
This may be related to issue #129 as well as [this issue](https://www.minecraftforum.net/forums/support/java-edition-support/2794297-why-is-liquid-bounce-crashing), [this SKLauncher crash](https://www.spigotmc.org/threads/i-cant-run-sklauncher-on-ubuntu-15-10.99978/), and [this random pastebin](https://pastebin.com/ydJvJGv9)

xrandr: ```
Screen 0: minimum 8 x 8, current 1920 x 1080, maximum 32767 x 32767
LVDS1 connected 1920x1080+0+0 (normal left inverted right x axis y axis) 310mm x 170mm
   1920x1080     60.00*+  59.93  
   1680x1050     59.88  
   1600x1024     60.17  
   1400x1050     59.98  
   1600x900      60.00  
   1280x1024     60.02  
   1440x900      59.89  
   1280x960      60.00  
   1368x768      60.00  
   1360x768      59.80    59.96  
   1152x864      60.00  
   1280x720      60.00  
   1024x768      60.00  
   1024x576      60.00  
   960x540       60.00  
   800x600       60.32    56.25  
   864x486       60.00  
   640x480       59.94  
   720x405       60.00  
   640x360       60.00  
DP1 disconnected (normal left inverted right x axis y axis)
DP2 disconnected (normal left inverted right x axis y axis)
DP3 disconnected (normal left inverted right x axis y axis)
HDMI1 disconnected (normal left inverted right x axis y axis)
HDMI2 disconnected (normal left inverted right x axis y axis)
HDMI3 disconnected (normal left inverted right x axis y axis)
VGA1 disconnected 1920x1080+0+0 (normal left inverted right x axis y axis) 0mm x 0mm
VIRTUAL1 disconnected (normal left inverted right x axis y axis)
  1920x1080 (0x4d) 148.500MHz +HSync +VSync
        h: width  1920 start 2008 end 2052 total 2200 skew    0 clock  67.50KHz
        v: height 1080 start 1084 end 1089 total 1125           clock  60.00Hz
```
